### PR TITLE
Add additional valid canoe values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ planet-waterway-boatable.geojsons: planet-waterway.osm.pbf
 	mv tmp.$@ $@
 
 planet-waterway-canoeable.geojsons: planet-waterway.osm.pbf
-	osm-lump-ways -i $< -o tmp.$@ --min-length-m 100 --save-as-linestrings -f canoe∈yes,portage,permissive,designated,destination,customers
+	osm-lump-ways -i $< -o tmp.$@ --min-length-m 100 --save-as-linestrings -f canoe∈yes,portage,permissive,designated,destination,customers,permit
 	mv tmp.$@ $@
 
 planet-waterway-all.geojsons: planet-waterway.osm.pbf

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ planet-waterway-boatable.geojsons: planet-waterway.osm.pbf
 	mv tmp.$@ $@
 
 planet-waterway-canoeable.geojsons: planet-waterway.osm.pbf
-	osm-lump-ways -i $< -o tmp.$@ --min-length-m 100 --save-as-linestrings -f canoe∈yes,portage
+	osm-lump-ways -i $< -o tmp.$@ --min-length-m 100 --save-as-linestrings -f canoe∈yes,portage,permissive,designated,destination,customers
 	mv tmp.$@ $@
 
 planet-waterway-all.geojsons: planet-waterway.osm.pbf


### PR DESCRIPTION
@amandasaurus Thanks for this excellent tool! I've been canoe mapping in the northeast US and noticed some canoeable ways aren't showing up. `canoe` is an access tag so I've added some missing access values. Not sure if `canoe=private` is desirable to show so I left it out.