### PR TITLE
Add dark mode support to main page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-bs-theme="light">
+<html lang="en" data-bs-theme="auto">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="data:," />
@@ -650,6 +650,7 @@
       </div>
     </template>
 
+    <script src="js/theme.js"></script>
     <script src="js/lib/bootstrap-5.3.3.bundle.min.js" async></script>
     <script src="js/lib/alpine-3.12.3.js" defer></script>
     <script src="js/lib/maplibre-gl-2.4.0.js"></script>


### PR DESCRIPTION
The website already has dark mode support, except on the main map view page. In wake of the recent addition of dark mode on https://www.openstreetmap.org/ I feel it's a good time to implement it.

- Theme will match the user preference of the browser or operating system
- This does not affect the map (no dimming whatsoever)
- At the moment I have no plans to create an override theme switcher

## Images
![Screenshot on home page](https://github.com/user-attachments/assets/60b9d886-9f0b-4d78-ad92-5c2ef7b754f6)
![Screenshot with settings open](https://github.com/user-attachments/assets/e5494f3d-5fe4-40c0-b15b-b852a6994fa5)
