### PR TITLE
Add scale control and disable map skew/rotate

### DIFF
--- a/docs/js/setup.js
+++ b/docs/js/setup.js
@@ -98,6 +98,15 @@ document.addEventListener("alpine:init", async () => {
 
   map.setPadding({ top: 57 });
 
+  var scale = new maplibregl.ScaleControl({
+    maxWidth: 200,
+    unit: "metric",
+  });
+  map.addControl(scale);
+  
+  map.dragRotate.disable();
+  map.touchZoomRotate.disableRotation();
+  
   map.on("load", () => {
     let select = document.querySelector("#selected_tileset");
     select.addEventListener("change", (e) => {


### PR DESCRIPTION
A couple bits and bobs from TIGER map in case you think these would be nice for WWM. Disabling the right click to rotate behavior is the main thing.