### PR TITLE
Exclude waterway=access_point

### DIFF
--- a/flowing_water.tagfilterfunc
+++ b/flowing_water.tagfilterfunc
@@ -16,6 +16,10 @@ waterway=seaway→F;
 waterway∈put_in,link,egress→F;
 waterway=put_in\u{3B}egress→F;     # semicolon in tag value messing things up
 
+# Canoeists also use https://wiki.openstreetmap.org/wiki/Tag:waterway=access_point
+# Should be mapped as node, but sometimes isnt. Exclude these loops.
+waterway∈access_point→F;
+
 # Often locks on big rivers are `waterway=canal` with `lock=yes`. Since the
 # rivers flow through them, they should be included.
 waterway=canal∧lock∈yes,disused→T;


### PR DESCRIPTION
https://waterwaymap.org/loops/#map=15.79/50.073133/10.95346 shows https://www.openstreetmap.org/way/580232959/history, which falls through the loop detection cracks because it was mapped with `whitewater=put_in;egress` (which is excluded already from the loop view) and now is `waterway=access_point` + `canoe=put_in;egress`.

I'm honestly not sure if I excluded the thing correctly, but it's an equally honest try.